### PR TITLE
Set MI score as confidence on exported interactions

### DIFF
--- a/intact-graphdb-service/pom.xml
+++ b/intact-graphdb-service/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.graphdb</groupId>
         <artifactId>intact-graphdb-module</artifactId>
-        <version>3.0.36-SNAPSHOT</version>
+        <version>3.0.37-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-graphdb-service</artifactId>

--- a/intact-graphdb-service/src/main/java/uk/ac/ebi/intact/graphdb/model/nodes/GraphBinaryInteractionEvidence.java
+++ b/intact-graphdb-service/src/main/java/uk/ac/ebi/intact/graphdb/model/nodes/GraphBinaryInteractionEvidence.java
@@ -9,6 +9,7 @@ import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.annotation.Transient;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import psidev.psi.mi.jami.binary.BinaryInteractionEvidence;
+import psidev.psi.mi.jami.model.Confidence;
 import psidev.psi.mi.jami.model.CvTerm;
 import psidev.psi.mi.jami.model.InteractionEvidence;
 import psidev.psi.mi.jami.model.Interactor;
@@ -263,6 +264,11 @@ public class GraphBinaryInteractionEvidence extends GraphInteractionEvidence imp
     //TODO Needs to be implemented
     public void setCausalRegulatoryMechanism(CvTerm causalRegulatoryMechanism) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Confidence getMiScore() {
+        return getClusteredInteraction();
     }
 
     public boolean isAlreadyCreated() {

--- a/intact-graphdb-service/src/main/java/uk/ac/ebi/intact/graphdb/model/nodes/GraphClusteredInteraction.java
+++ b/intact-graphdb-service/src/main/java/uk/ac/ebi/intact/graphdb/model/nodes/GraphClusteredInteraction.java
@@ -6,7 +6,10 @@ import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
 import org.neo4j.ogm.annotation.Transient;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
+import psidev.psi.mi.jami.model.Confidence;
+import psidev.psi.mi.jami.model.CvTerm;
 import psidev.psi.mi.jami.model.Interactor;
+import psidev.psi.mi.jami.model.impl.DefaultCvTerm;
 import uk.ac.ebi.intact.graphdb.beans.NodeDataFeed;
 import uk.ac.ebi.intact.graphdb.model.domain.ClusterDataFeed;
 import uk.ac.ebi.intact.graphdb.model.relationships.RelationshipTypes;
@@ -22,7 +25,7 @@ import java.util.Set;
  * Created by anjali on 06/03/18.
  */
 @NodeEntity
-public class GraphClusteredInteraction extends GraphDatabaseObject {
+public class GraphClusteredInteraction extends GraphDatabaseObject implements Confidence {
 
     @Index(unique = true, primary = true)
     private String uniqueKey;
@@ -160,5 +163,15 @@ public class GraphClusteredInteraction extends GraphDatabaseObject {
 
     public String createUniqueKey() {
         return UniqueKeyGenerator.createClusteredInteractionKey(this);
+    }
+
+    @Override
+    public CvTerm getType() {
+        return new DefaultCvTerm("intact-miscore");
+    }
+
+    @Override
+    public String getValue() {
+        return Double.toString(miscore);
     }
 }

--- a/intact-graphdb-ws/pom.xml
+++ b/intact-graphdb-ws/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.ac.ebi.intact.graphdb</groupId>
         <artifactId>intact-graphdb-module</artifactId>
-        <version>3.0.36-SNAPSHOT</version>
+        <version>3.0.37-SNAPSHOT</version>
     </parent>
 
     <artifactId>intact-graphdb-ws</artifactId>

--- a/intact-graphdb-ws/src/main/java/uk/ac/ebi/intact/graphdb/ws/controller/ExportController.java
+++ b/intact-graphdb-ws/src/main/java/uk/ac/ebi/intact/graphdb/ws/controller/ExportController.java
@@ -26,6 +26,7 @@ import psidev.psi.mi.jami.xml.PsiXmlVersion;
 import uk.ac.ebi.intact.graphdb.model.nodes.GraphBinaryInteractionEvidence;
 import uk.ac.ebi.intact.graphdb.model.nodes.GraphInteractionEvidence;
 import uk.ac.ebi.intact.graphdb.service.GraphInteractionService;
+import uk.ac.ebi.intact.graphdb.ws.controller.expansion.GraphDbExpansionMethod;
 import uk.ac.ebi.intact.graphdb.ws.controller.model.InteractionExportFormat;
 import uk.ac.ebi.intact.search.interactions.model.SearchInteraction;
 import uk.ac.ebi.intact.search.interactions.service.InteractionSearchService;
@@ -250,15 +251,15 @@ public class ExportController {
                 break;
             case miTab25:
                 writer = writerFactory.getInteractionWriterWith(optionFactory.getMitabOptions(output, InteractionCategory.evidence,
-                        ComplexType.n_ary, new InteractionEvidenceSpokeExpansion(), true, MitabVersion.v2_5, false));
+                        ComplexType.n_ary, new GraphDbExpansionMethod(), true, MitabVersion.v2_5, false));
                 break;
             case miTab26:
                 writer = writerFactory.getInteractionWriterWith(optionFactory.getMitabOptions(output, InteractionCategory.evidence,
-                        ComplexType.n_ary, new InteractionEvidenceSpokeExpansion(), true, MitabVersion.v2_6, false));
+                        ComplexType.n_ary, new GraphDbExpansionMethod(), true, MitabVersion.v2_6, false));
                 break;
             case miTab27:
                 writer = writerFactory.getInteractionWriterWith(optionFactory.getMitabOptions(output, InteractionCategory.evidence, ComplexType.n_ary,
-                        new InteractionEvidenceSpokeExpansion(), true, MitabVersion.v2_7, false));
+                        new GraphDbExpansionMethod(), true, MitabVersion.v2_7, false));
                 break;
             case miJSON:
             default:

--- a/intact-graphdb-ws/src/main/java/uk/ac/ebi/intact/graphdb/ws/controller/expansion/GraphDbExpansionMethod.java
+++ b/intact-graphdb-ws/src/main/java/uk/ac/ebi/intact/graphdb/ws/controller/expansion/GraphDbExpansionMethod.java
@@ -1,0 +1,45 @@
+package uk.ac.ebi.intact.graphdb.ws.controller.expansion;
+
+import psidev.psi.mi.jami.binary.expansion.ComplexExpansionMethod;
+import psidev.psi.mi.jami.exception.ComplexExpansionException;
+import psidev.psi.mi.jami.factory.BinaryInteractionFactory;
+import psidev.psi.mi.jami.model.CvTerm;
+import uk.ac.ebi.intact.graphdb.model.nodes.GraphBinaryInteractionEvidence;
+import uk.ac.ebi.intact.graphdb.model.nodes.GraphInteractionEvidence;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class GraphDbExpansionMethod implements ComplexExpansionMethod<GraphInteractionEvidence, GraphBinaryInteractionEvidence> {
+
+    @Override
+    public CvTerm getMethod() {
+        return null;
+    }
+
+    @Override
+    public boolean isInteractionExpandable(GraphInteractionEvidence interaction) {
+        if (interaction == null || interaction.getParticipants().isEmpty()){
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Collection<GraphBinaryInteractionEvidence> expand(GraphInteractionEvidence interaction) throws ComplexExpansionException {
+        if (interaction instanceof GraphBinaryInteractionEvidence) {
+            return Collections.singletonList((GraphBinaryInteractionEvidence) interaction);
+        }
+        return interaction.getBinaryInteractionEvidences();
+    }
+
+    @Override
+    public BinaryInteractionFactory getBinaryInteractionFactory() {
+        return null;
+    }
+
+    @Override
+    public void setBinaryInteractionFactory(BinaryInteractionFactory factory) {
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>uk.ac.ebi.intact.graphdb</groupId>
     <artifactId>intact-graphdb-module</artifactId>
-    <version>3.0.36-SNAPSHOT</version>
+    <version>3.0.37-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>IntAct Portal :: Graph DB Core</name>
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
-        <psi.jami.version>3.2.10</psi.jami.version>
+        <psi.jami.version>3.4.0-SNAPSHOT</psi.jami.version>
         <search.interaction.service.version>1.0.8-SNAPSHOT</search.interaction.service.version>
         <neo4j.version>3.2.13</neo4j.version>
     </properties>


### PR DESCRIPTION
Currently, Intact Portal does not include the MI score in the MITAB files.

`GraphBinaryInteractionEvidence` has now a `getMiScore` method which returns the MI score (already stored in Neo4J as part of the `GraphClusteredInteraction` nodes. This change, along with the changes in psi-jami (https://github.com/MICommunity/psi-jami/pull/80) fixes this bug.

Because of the spoke expansion done when calling `write` with an n-ary interaction, we may lose the MI score. To avoid that, and given that we already have the interactions expanded in Neo4J, we now have a new implementation of the expansion interface that simply calls `GraphInteractionEvidence.getBinaryInteractionEvidences` to get the binary interactions from an n-ary interaction.

I've tested this changes on both endpoints, the one to export from search based on a query and the one to export from an interaction AC, and it works for both cases.

